### PR TITLE
Release 1.9.4: libuiohook crash fix, TARGET_OS_MAC build fix, rescope to @zelloptt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zelloptt/desktop-hotkeys",
-  "version": "1.9.2",
+  "version": "1.9.4",
   "description": "This package provides press/release callbacks for system-wide hotkeys on Windows and Mac",
   "main": "index.js",
   "gypfile": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "desktop-hotkeys",
+  "name": "@zelloptt/desktop-hotkeys",
   "version": "1.9.2",
   "description": "This package provides press/release callbacks for system-wide hotkeys on Windows and Mac",
   "main": "index.js",

--- a/src/AccessibilityMac.mm
+++ b/src/AccessibilityMac.mm
@@ -1,5 +1,4 @@
 #include "Hotkeys.h"
-#define TARGET_OS_MAC
 #import <Foundation/Foundation.h>
 #import <ApplicationServices/ApplicationServices.h>
 #import <AppKit/AppKit.h>

--- a/src/HotkeysMac.mm
+++ b/src/HotkeysMac.mm
@@ -1,5 +1,4 @@
 #include "Hotkeys.h"
-#define TARGET_OS_MAC
 #import <Foundation/Foundation.h>
 #import <ApplicationServices/ApplicationServices.h>
 #import <AppKit/AppKit.h>


### PR DESCRIPTION
## Summary

Release **@zelloptt/desktop-hotkeys@1.9.4**, which rolls up three changes on top of the 1.9.2 tree:

1. **Bump `libuiohook` by one commit** from `32bcd76` (tip of the `dh` fork branch, pinned here since Dec 2021) to `8ad96f8`, which is `32bcd76` + a single cherry-picked commit: `darwin: drop redundant CFRunLoopObserverInvalidate in teardown`. See zelloptt/libuiohook's `dh-cfinvalidate` branch — the diff is **1 file (`src/darwin/input_hook.c`), 8 insertions / 3 deletions**.
2. **Drop empty `#define TARGET_OS_MAC`** from `src/HotkeysMac.mm` and `src/AccessibilityMac.mm`. The empty define overrides the correct value supplied by `<TargetConditionals.h>` on recent Xcode SDKs, which breaks `build-from-source` on modern macOS.
3. **Rescope package name** from unscoped `desktop-hotkeys` to **`@zelloptt/desktop-hotkeys`** so publishes can proceed under the `@zelloptt` npm org. The previous unscoped package is owned solely by a former maintainer's personal npm account that Zello no longer has access to. Git repo stays the same; node-pre-gyp's `binary.module_name` is unchanged, so existing S3 prebuilt-binary paths keep working.

## Why: the crash fix (commit 1)

Production macOS Electron hosts show recurring `EXC_BREAKPOINT (SIGTRAP)` / `EXC_ARM_BREAKPOINT` crashes on arm64 during application quit, with a consistent faulting frame:

```
__CFCheckCFInfoPACSignature
CFRunLoopObserverInvalidate
destroy_event_runloop_info   (libuiohook, src/darwin/input_hook.c)
hook_event_proc_proc         (libuiohook)
```

The root cause is inside libuiohook's Darwin teardown: after `CFRunLoopRemoveObserver` has released the run-loop's ownership of the observer, the subsequent `CFRunLoopObserverInvalidate` can re-enter a path that runs a PAC-signature check against a `CFRuntimeBase` that has already been torn down, which Apple's arm64 CoreFoundation deliberately traps on.

`CFRelease` alone is sufficient to destroy an owned observer after it has been removed from the run-loop, so the explicit `CFRunLoopObserverInvalidate` call was redundant. Removing it eliminates the crash on arm64 macOS without changing observable behaviour on other platforms.

## Why: the build fix (commit 2)

Rebuilding from source on a fresh macOS dev machine surfaces:

```
Foundation.h:... error: expected value in expression
NSObjCRuntime.h:... error: invalid token at start of a preprocessor expression
```

This is caused by two empty `#define TARGET_OS_MAC` lines that were originally added to coerce Foundation behaviour, but on modern Xcode SDKs `<TargetConditionals.h>` defines `TARGET_OS_MAC` to `1`, and overriding it with nothing breaks preprocessor arithmetic inside system headers. Removing them is a no-op on the host (arch is still correctly detected via `TargetConditionals.h`) and fixes `build-from-source` for consumers who don't have a matching prebuilt.

## Why: the rescope (commits 3 and 4)

The unscoped `desktop-hotkeys` package is owned by a single former-maintainer npm account with no live Zello collaborators, and npm's CLI has no way for us to self-promote. The scoped `@zelloptt/desktop-hotkeys` is owned by the `@zelloptt` npm org and publishable by current org owners today, so the release goes there. Downstream consumers need to switch their dependency from `desktop-hotkeys` to `@zelloptt/desktop-hotkeys` (a one-line change in each `require` / `import`).

## Release artifacts

- npm: https://www.npmjs.com/package/@zelloptt/desktop-hotkeys/v/1.9.4 (published, `latest` dist-tag)
- git tag: `v1.9.4` → `7d8ed93`
- deprecated on npm: 1.9.3 (see deprecation message: same fix but unintentionally wider submodule bump; 1.9.4 is the canonical release)

Prebuilt binaries uploaded to `s3://zello-desktop/desktop_hotkeys/v1.9.4/Release/`:

| Tarball | Source |
|---|---|
| `napi-v4-darwin-arm64.tar.gz` | built on M1 from this branch |
| `napi-v4-darwin-x64.tar.gz` | built on M1 under Rosetta (`arch -x86_64 node`) from this branch |
| `napi-v4-win32-x64.tar.gz` | copied from v1.9.2 (no Windows code changed) |
| `napi-v4-win32-ia32.tar.gz` | copied from v1.9.2 (no Windows code changed) |

End-to-end install test (`npm install @zelloptt/desktop-hotkeys@1.9.4` in a scratch dir) fetches the arm64 prebuilt from S3 and loads successfully under Node 20.

## Test plan

- [x] libuiohook patched and built; 10-iteration smoke test passed
- [x] `desktop-hotkeys` rebuilt from source on arm64 and x86_64 macOS; both bundles produced correct Mach-O
- [x] libuiohook submodule diff verified minimal (1 file, 8 +, 3 -)
- [x] All four v1.9.4 tarballs uploaded to S3 with public read
- [x] End-to-end `npm install @zelloptt/desktop-hotkeys@1.9.4` fetches prebuilt and `require()` succeeds
- [ ] Wire the new scoped dependency into `zello-desktop` and run dispatch-hub locally to reproduce the original crash trace and confirm it no longer occurs (pending follow-up PR on `zello-desktop`)

## Base branch note

Base is `master-reset` (the clean 1.9.2 + PR #18 history, PR #27). Once PR #27 lands, this can retarget to master cleanly.
