### PR TITLE
Sync master with master-reset (release 1.9.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "desktop-hotkeys",
-  "version": "1.9.2",
+  "name": "@zelloptt/desktop-hotkeys",
+  "version": "1.9.4",
   "description": "This package provides press/release callbacks for system-wide hotkeys on Windows and Mac",
   "main": "index.js",
   "gypfile": true,

--- a/src/AccessibilityMac.mm
+++ b/src/AccessibilityMac.mm
@@ -1,5 +1,4 @@
 #include "Hotkeys.h"
-#define TARGET_OS_MAC
 #import <Foundation/Foundation.h>
 #import <ApplicationServices/ApplicationServices.h>
 #import <AppKit/AppKit.h>

--- a/src/HotkeysMac.mm
+++ b/src/HotkeysMac.mm
@@ -1,5 +1,4 @@
 #include "Hotkeys.h"
-#define TARGET_OS_MAC
 #import <Foundation/Foundation.h>
 #import <ApplicationServices/ApplicationServices.h>
 #import <AppKit/AppKit.h>


### PR DESCRIPTION
Bring the changes from #28 (already merged into `master-reset`) onto `master`.

This branch is `master` + a single cherry-pick of the #28 squash merge commit. The resulting tree matches `master-reset` HEAD byte-for-byte (`git diff master-reset...sync-1.9.4-to-master` is empty).

Replaces #29, which GitHub flagged as conflicted due to divergent DAG history between `master` and `master-reset` — both branches had modified `package.json` relative to their old common ancestor, even though the desired resolution was simply "take `master-reset`'s version". Cherry-picking onto a fresh branch off `master` sidesteps the 3-way merge entirely.

## Diff

```
libuiohook              | 2 +-   submodule bump to the dh-cfinvalidate fix commit
package.json            | 4 ++--  name → @zelloptt/desktop-hotkeys, version → 1.9.4
src/AccessibilityMac.mm | 1 -    drop empty #define TARGET_OS_MAC
src/HotkeysMac.mm       | 1 -    drop empty #define TARGET_OS_MAC
4 files changed, 3 insertions(+), 5 deletions(-)
```

## Background

- #27 (already merged) reset `master` to `v1.9.2 + PR #18 replay`.
- #28 (already merged into `master-reset`) added the libuiohook crash fix, the `TARGET_OS_MAC` build fix, and the rescope/version bump that shipped as `@zelloptt/desktop-hotkeys@1.9.4`. Prebuilt binaries live at `s3://zello-desktop/desktop_hotkeys/v1.9.4/Release/` and the package is consumed by zelloptt/zello-desktop#3448.
- This PR brings those changes onto `master`.

## Merge strategy

Either "Squash and merge" or "Create a merge commit" is fine here — there's only one commit on the branch and it's already a squash of #28's contents.

## Test plan

No code changes vs. the already-merged #28. CI on `master` should be green for the same reasons it was green on `master-reset`.
