### PR TITLE
Release 1.9.5: Electron-targeted prebuild scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,42 @@
-# desktop-hotkeys
-This package provides press/release callbacks for system-wide hotkeys on Windows
+## desktop-hotkeys
+
+Press/release callbacks for system-wide hotkeys on Windows and macOS.
 
 ## Installation
 
-```npm install --save desktop-hotkeys```
+```
+npm install --save @zelloptt/desktop-hotkeys
+```
+
+`npm install` runs `node-pre-gyp install --fallback-to-build`, which downloads
+a prebuilt binary from the S3 host configured under `binary.host` in
+`package.json`. If no matching prebuilt is found, the package builds from
+source against the active Node runtime headers.
 
 ## Usage
-You can find a minimal working sample in the ```sample``` subfolder
+
+A minimal working sample lives in `sample/`.
+
+## Building prebuilts
+
+The published prebuilts must be ABI-compatible with the runtime that loads
+them. A binary built against Node headers and loaded inside Electron — even
+when both share the same N-API version — can register hotkeys without error
+yet silently drop key events on the JS callback path. Always rebuild and
+republish prebuilts whenever the consumer's Electron major version changes.
+
+To rebuild and publish prebuilts targeted at a specific Electron version,
+set `ELECTRON_TARGET` and run the matching `make-electron*` script:
+
+```
+ELECTRON_TARGET=37.10.3 npm run make-electronM1   # darwin arm64
+ELECTRON_TARGET=37.10.3 npm run make-electron64   # darwin / win32 x64
+```
+
+The `make` / `make64` / `makeM1` scripts retain their original Node-runtime
+behaviour for any consumer still loading the module under plain Node.
+
+Each release should re-publish prebuilts for every (platform, arch, runtime)
+the consumer ships against. A consumer that downloads a prebuilt built for a
+different runtime will load it without an error and may then hit the silent-
+event-loss mode described above.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zelloptt/desktop-hotkeys",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "This package provides press/release callbacks for system-wide hotkeys on Windows and Mac",
   "main": "index.js",
   "gypfile": true,
@@ -11,6 +11,11 @@
     "make64": "node-pre-gyp rebuild --build-from-source --verbose --target_arch=x64 package unpublish publish",
     "makeM1": "node-pre-gyp rebuild --build-from-source --verbose --target_arch=arm64 package publish",
     "makeM11": "node-pre-gyp rebuild --build-from-source --verbose --target_arch=arm64",
+    "make-electron": "node-pre-gyp rebuild --build-from-source --verbose --runtime=electron --dist-url=https://electronjs.org/headers --target=$ELECTRON_TARGET package publish",
+    "make-electron32": "node-pre-gyp rebuild --build-from-source --verbose --runtime=electron --dist-url=https://electronjs.org/headers --target=$ELECTRON_TARGET --target_arch=ia32 package publish",
+    "make-electron64": "node-pre-gyp rebuild --build-from-source --verbose --runtime=electron --dist-url=https://electronjs.org/headers --target=$ELECTRON_TARGET --target_arch=x64 package unpublish publish",
+    "make-electronM1": "node-pre-gyp rebuild --build-from-source --verbose --runtime=electron --dist-url=https://electronjs.org/headers --target=$ELECTRON_TARGET --target_arch=arm64 package publish",
+    "make-electronM11": "node-pre-gyp rebuild --build-from-source --verbose --runtime=electron --dist-url=https://electronjs.org/headers --target=$ELECTRON_TARGET --target_arch=arm64",
     "maked": "node-pre-gyp rebuild --build-from-source --debug --verbose",
     "test": "echo \"Test not applicable\""
   },


### PR DESCRIPTION
## Summary

- Bump `@zelloptt/desktop-hotkeys` 1.9.4 → 1.9.5 so consumers can pin past the broken 1.9.4 prebuilt set.
- Add `make-electron` / `make-electron32` / `make-electron64` / `make-electronM1` / `make-electronM11` scripts that drive `node-pre-gyp` with the Electron runtime/headers and accept the target Electron version via the `ELECTRON_TARGET` env var.
- Document the rebuild-per-Electron-major-version requirement in `README.md`.

## Why

The 1.9.4 prebuilts published to S3 were built against Node runtime headers. Loading the resulting binary inside Electron 37 (Node 22 base, same N-API v4 ABI) registers hotkeys without error but silently drops key events on the threadsafe-function callback path — `Hotkey pressed` callbacks never fire in the consumer, so PTT and other global hotkeys appear inert.

Rebuilding this same source tree with

```
--runtime=electron --target=37.10.3 --dist-url=https://electronjs.org/headers
```

and dropping the resulting `desktop_hotkeys.node` into the consumer's `node_modules/@zelloptt/desktop-hotkeys/lib/binding/napi-v4/` restores press/release delivery. The failure is therefore an Electron-vs-Node ABI mismatch in the published prebuilt, not a source regression.

## Test plan

- [x] Verified locally: rebuilt darwin-arm64 against Electron 37.10.3, swapped binary into a consumer running Electron 37, PTT (`shift+a`) press and release events now reach the JS callback.
- [ ] Maintainer runs `ELECTRON_TARGET=<version> npm run make-electron*` on each (platform, arch) host the consumer ships against and publishes the resulting tarballs to S3 under `desktop_hotkeys/v1.9.5/Release/`.
- [ ] Consumer (`zello-desktop`) bumps `@zelloptt/desktop-hotkeys` to `1.9.5` once prebuilts are live.

https://zelloptt.atlassian.net/browse/DESKTOP-584