### PR TITLE
DESKTOP-529: Fix Linux empty impl compile errors (1.9.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zelloptt/desktop-hotkeys",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "This package provides press/release callbacks for system-wide hotkeys on Windows and Mac",
   "main": "index.js",
   "gypfile": true,

--- a/src/HotkeysLinuxEmptyImpl.cpp
+++ b/src/HotkeysLinuxEmptyImpl.cpp
@@ -70,10 +70,10 @@ Napi::Boolean HotKeys::macCheckAccessibilityGranted(const Napi::CallbackInfo& in
 
 Napi::Array HotKeys::convertHotkeysCodes(const Napi::CallbackInfo& info)
 {
-	return return emptyImpl<Napi::Array, size_t>(env, 0);
+	return emptyImpl<Napi::Array, size_t>(info, 0);
 }
 
-Napi::Number checkHotkeyConflicts(const Napi::CallbackInfo& info);
+Napi::Number HotKeys::checkHotkeyConflicts(const Napi::CallbackInfo& info)
 {
 	return emptyImpl<Napi::Number, unsigned>(info, 0);
 }


### PR DESCRIPTION
## Summary

`@zelloptt/desktop-hotkeys@1.9.4` cannot be installed from source on Linux because `src/HotkeysLinuxEmptyImpl.cpp` contains two unrelated compile errors. Linux x64 napi-v4 prebuilts aren't published to the S3 bucket either, so node-pre-gyp falls back to source compile and `npm install` fails on every linux runner.

This blocks the new `zello-desktop` smoke gate (which runs on \`ubuntu-latest\`) until the published version is fixed.

## Bugs fixed

\`HotkeysLinuxEmptyImpl.cpp\`:

1. \`convertHotkeysCodes\` returned \`return return emptyImpl<>(env, 0)\` — both a doubled \`return\` keyword and a reference to undeclared \`env\`. The other empty stubs in the same file pass \`info\` to \`emptyImpl\`, which derives \`env\` internally. Match that pattern.
2. \`checkHotkeyConflicts\` was declared \`Napi::Number checkHotkeyConflicts(const Napi::CallbackInfo& info);\` (missing the \`HotKeys::\` qualifier and a stray \`;\` between the parameter list and the body). The compiler then treated the next \`{\` as a global-scope orphan and bailed.

Both of these are dead-code stubs on Linux (the package has no real Linux implementation) but they need to compile so the binding can load and \`emptyImpl\` can throw the \"procedure not implemented on linux\" \`TypeError\` at runtime.

## Why bump to 1.9.5

So the consumer side (\`zello-desktop/package.json\`) can pin to \`^1.9.5\` and drop the workflow-level sed patch we ship as a stopgap.

## Test plan

- [ ] CI: \`npm run prebuild\` (or whatever the maintainer-side build is) compiles \`HotkeysLinuxEmptyImpl.cpp\` cleanly on linux-x64.
- [ ] Verify the existing macOS / Windows builds still pass (the file is Linux-only; these branches should be untouched).
- [ ] After merge + npm publish: bump \`zello-desktop\` to \`^1.9.5\` and re-run the smoke workflow; the workflow-level sed patch becomes a no-op safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)